### PR TITLE
Retry failed queries

### DIFF
--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -259,12 +259,11 @@ async function findServices(state) {
     }
     process.stdout.write(`\b\b\b done. Actual service count is ${Object.values(state.applications).length}.\n`);
 
-    // We prefer findModulesByAccount() because it uses a more efficent API, and we've
-    //   found some cases where a service may not be returned by the entitySearch query.
-    // If you are mucking around in here and find a need to run a query per entity,
-    //   pass in the undocumented `--entity-scan` command-line arg and then you 
-    //   can do interesting things in findModulesByEntity().
-    if (process.argv.includes('--entity-scan')) {
+    // We prefer findModulesByAccount() because it uses a more efficent API, but we've
+    //   found some cases where we're not getting complete results.
+    // We'll default to an api call per java service until I can figure it out the disparity.
+    // Use the `--quick-scan` undocumented command line arg to use the account-level query.
+    if (! process.argv.includes('--quick-scan')) {
         await findModulesByEntity(state);
     } else {
         await findModulesByAccount(state);

--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -346,19 +346,24 @@ async function findModulesByEntity(state) {
                 const moduleResults = data['actor']['account']['agentEnvironment']['modules']['results'];
                 for (const result of moduleResults || []) {
                     if (result['loadedModules'].length > 0) {
+                        const {name, host} = result['details'];
+                        const appName = name.replace(/^java:/, '').replace(/:\d+$/, '');
                         const entityGuids = result['applicationGuids'];
 
                         for (const module of result['loadedModules']) {
+                            if (!entityGuids || entityGuids.length < 1) {
+                                process.stdout.write(`\nWarning: result w/out a guid found:\t${appName}\t${host}\t${module['name']}\t${module['version']}      `);
+                            }
+
                             for (const guid of entityGuids) {
                                 if (!state.applications[guid]) {
                                   // There are rare cases where entitySearch doesn't return every application
                                   // If we find one of those, construct an application record from the data we have here
                                   const applicationId = getApplicationIdFromGuid(guid);
-                                  const {name, host} = result['details'];
                                   state.applications[guid] = {
                                     accountId,
                                     guid,
-                                    name,
+                                    name: appName,
                                     applicationId,
                                     nrUrl: (applicationId) ? `https://rpm.newrelic.com/accounts/${accountId}/applications/${applicationId}/environment` : ''
                                   }


### PR DESCRIPTION
This PR:

* refactors the `nerdgraphQuery()` function to do a single retry on each NerdGraph query if we get either a network error or get a response without valid {"data": ...} content. I took the opportunity to DRY up the http request code.
* reverts the scanning method to use an api call per entity, rather than using the account-wide module query api. The account modules query is more efficient but I'm seeing inconsistent results that we need to investigate further.
