### PR TITLE
Add region selection and agent version

### DIFF
--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -472,7 +472,7 @@ function writeResults(state) {
     }
 
     if (useCsv) {
-        const columns = ['accountId', 'applicationId', 'name', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
+        const columns = ['accountId', 'applicationId', 'name', 'agentVersion', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
         const outputFile = `log4j_scan_${state.region}_${fileTimestamp}.csv`;
         // DIY rather than depend on a csv module
         fs.writeFileSync(


### PR DESCRIPTION
This PR allows the user to switch between US and EU regions, using US as the default. 

Also taking the opportunity to add `agentVersion` to the  CSV output file so you can see what New Relic agent version is in each service.