### PR TITLE
Scan the JVM Arguments for presence of mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Command-line options:
 --all-services  include services that do NOT report presence of log4j-core
 ```
 
+## Output
+
+The CSV and JSON files contain these fields:
+
+* `accountId`           New Relic account id containing the service
+* `applicationId`       New Relic application id of the service
+* `name`                Display name of the service as seen in New Relic
+* `examinedInstances`   Number of runtime instances of the service that were examined
+* `upgradedInstances`   Number of examined instances that report using Log4j version 2.15+
+* `mitigatedInstances`  Number of examined instances that report using the `-Dlog4j2.formatMsgNoLookups=true` JVM argument mitigation
+* `agentVersion`        New Relic agent version detected in the service
+* `log4jJar`            Name of the log4j-core jar file detected in the service
+* `log4jJarVersion`     Version string of the log4j-core library detected in the service
+* `log4jJarSha1`        SHA1 hash of the log4j-core jar file
+* `log4jJarSha512`      SHA512 hash of the log4j-core jar file
+* `nrUrl`               Link to the New Relic UI to examine the service's environment data
+
 ## Auditing New Relic Java agent usage
 
 Per [Security Bulletin NR21-03](https://docs.newrelic.com/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03/), New Relic Java agent versions 7.4.1 and 6.5.1 contain updated Log4j2 libraries. To find out what version of the New Relic Java APM agent your services are running, use NRDB's `ApplicationAgentContext` events.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Command-line options:
 
 ## Output
 
+The output includes all Java services found to contain log4j-core, the vulnerable library.
+
+Our suggested analysis is:
+
+1. Check the version of log4j-core. Versions 2.0 through < 2.15.0 are known vulnerable.
+2. Verify you have upgraded the New Relic `agentVersion` to a known-safe [Java agent release](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/).
+3. Compare `examinedInstances` count on each service to the upgraded and mitigated instance counts to assess how many instances may still be vulnerable:
+   1. `upgradedInstances` indicates how many running instances have log4j-core ≥ 2.15. If all instances are "upgraded" then we did not detect a vulnerable version of the library.
+   2. `mitigatedInstances` indicates how many running instances have the `-Dlog4j2.formatMsgNoLookups=true` jvm argument applied.
+4. Use the `nrUrl` link to directly examine the service's runtime environment as reported by the Java agent
+
 The CSV and JSON files contain these fields:
 
 * `accountId`           New Relic account id containing the service

--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -472,7 +472,7 @@ function writeResults(state) {
     }
 
     if (useCsv) {
-        const columns = ['accountId', 'applicationId', 'name', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
+        const columns = ['accountId', 'applicationId', 'name', 'agentVersion', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
         const outputFile = `log4j_scan_${state.region}_${fileTimestamp}.csv`;
         // DIY rather than depend on a csv module
         fs.writeFileSync(

--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -336,8 +336,6 @@ async function findModulesByEntity(state) {
                                 application['log4jJarVersion'] = log4jVersion;
                                 if (log4jVersion.startsWith('2.15') || log4jVersion.startsWith('2.16')) {
                                     upgradedInstanceCount += 1;
-                                } else {
-                                    console.log('non-upgraded instance ', module)
                                 }
                                 if (module['attributes']) {
                                     for (const attribute of module['attributes']) {

--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -496,7 +496,7 @@ function writeResults(state) {
     }
 
     if (useCsv) {
-        const columns = ['accountId', 'applicationId', 'name', 'agentVersion', 'examinedInstances', 'upgradedInstances', 'mitigatedInstances', 'agentVersion', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
+        const columns = ['accountId', 'applicationId', 'name', 'agentVersion', 'examinedInstances', 'upgradedInstances', 'mitigatedInstances', 'log4jJar', 'log4jJarVersion', 'log4jJarSha1', 'log4jJarSha512', 'nrUrl'];
         const outputFile = `log4j_scan_${state.region}_${fileTimestamp}.csv`;
         // DIY rather than depend on a csv module
         fs.writeFileSync(


### PR DESCRIPTION
This PR adds logic to fetch `JVM Arguments` environment data from the API and examine it for presence of the `-Dlog4j2.formatMsgNoLookups=true` runtime mitigation flag.

Also added definitions of all output fields to the README