### PR TITLE
fix: avoid double-counting instances that have the -Dlog4j2.formatMsgNoLookups=true applied twice

### DIFF
--- a/nr-find-log4j.js
+++ b/nr-find-log4j.js
@@ -350,10 +350,8 @@ async function findModulesByEntity(state) {
                             }
                         }
                         if (instance['environmentAttributes']) {
-                            for (const attr of instance['environmentAttributes']) {
-                                if (attr['value'] === '-Dlog4j2.formatMsgNoLookups=true') {
-                                    hasArgMitigationCount += 1;
-                                }
+                            if (instance['environmentAttributes'].find(attr => attr['value'] === '-Dlog4j2.formatMsgNoLookups=true')) {
+                                hasArgMitigationCount += 1;
                             }
                         }
                     }


### PR DESCRIPTION
Previous logic would count every instance of the mitigating jvm arg in the command line or environment. This made it impossible to compare actual instances running vs mitigated instances. This PR re-works the logic so it only counts each instance once, regardless of how many times the jvm arg was specified in the command line.